### PR TITLE
Add support for de/serializing pathnames

### DIFF
--- a/cl-conspack.asd
+++ b/cl-conspack.asd
@@ -27,6 +27,7 @@
    (:file "indexes")
    (:file "tmap")
    (:file "array")
+   (:file "pathname")
    (:file "encode")
    (:file "decode")
    (:file "explain")))

--- a/doc/SPEC
+++ b/doc/SPEC
@@ -21,6 +21,7 @@ Conspack supports the following basic types:
     - Packages
     - Symbols
     - Indexes (i.e., externally-indexed symbols)
+    - Pathnames
 
 Containers can either contain arbitrary objects, which include their
 header, or a fixed type, which stores only the post-header data

--- a/src/pathname.lisp
+++ b/src/pathname.lisp
@@ -1,0 +1,18 @@
+(in-package #:conspack)
+
+;;;; This defines a simple encoding for pathnames via TMaps.
+
+(defmethod encode-object append ((object pathname) &key &allow-other-keys)
+  ;; Note that PATHNAME-HOST and PATHNAME-DEVICE are ignored since the
+  ;; types of them are implementation-dependent.
+  `((:directory . ,(pathname-directory object))
+    (:name . ,(pathname-name object))
+    (:type . ,(pathname-type object))
+    (:version . ,(pathname-version object))))
+
+(defmethod decode-object-allocate ((class (eql 'pathname)) alist
+                                   &key &allow-other-keys)
+  (apply #'make-pathname (alist-plist alist)))
+
+(defmethod decode-object-initialize progn ((pathname pathname) class alist &key &allow-other-keys)
+  (declare (ignore pathname class alist)))

--- a/t/encode-decode.lisp
+++ b/t/encode-decode.lisp
@@ -18,7 +18,7 @@
           (cycle (expt 2 31))
           (cycle (expt 2 63))
           (cycle (expt 2 127))
-          (cycle 5s0)
+          (cycle 5f0)
           (cycle 10d0)
           (cycle #C(0 1))
           (cycle 1/2)

--- a/t/encode-decode.lisp
+++ b/t/encode-decode.lisp
@@ -32,6 +32,10 @@
           (cycle "ሰማይ አይታረስ ንጉሥ አይከሰስ።")
           (cycle "ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ"))
 
+(5am:test pathnames
+          (cycle #P"path/to/file")
+          (cycle #P"/path/to/file"))
+
 (5am:test containers
           (let ((hash (make-hash-table)))
             (setf (gethash 5 hash) 50


### PR DESCRIPTION
This implemented the missing (de)serialization support for pathnames, where the implementation-dependent components are simply ignored.