### PR TITLE
Remove repeated object class identifiers and array identifiers from output

### DIFF
--- a/src/reftable.lisp
+++ b/src/reftable.lisp
@@ -92,10 +92,12 @@
                        (notice-recursively k context)
                        (notice-recursively v context)))
             ((or string package symbol r-ref pointer))
-            (t (let ((encoded-alist (encode-object object)))
-                 (notice-recursively encoded-alist context)
-                 (setf (gethash object (ref-context-encoded-objects context))
-                       encoded-alist))))))))
+            (t
+             (notice-recursively (object-class-identifier object))
+             (let ((encoded-alist (encode-object object)))
+               (notice-recursively encoded-alist context)
+               (setf (gethash object (ref-context-encoded-objects context))
+                     encoded-alist))))))))
 
 (defun referrable-p (object)
   (or (typep object 'sequence)


### PR DESCRIPTION
Previously:
```
(defstruct blarg)
(conspack:defencoding blarg)
(conspack:explain
	  (conspack:tracking-refs ()
	   (conspack:encode (list (make-blarg) (make-blarg)
                                  (make-array '(1 1)) (make-array '(1 1))))))
((:LIST 5
  ((:TMAP 0 ((:SYMBOL BLARG))) (:TMAP 0 ((:SYMBOL BLARG)))
   (:TMAP 3
    ((:SYMBOL ARRAY) (:TAG 0 (:SYMBOL :DIMENSIONS))
     (:LIST 3 ((:NUMBER :INT8 1) (:NUMBER :INT8 1) (:BOOLEAN NIL)))
     (:TAG 1 (:SYMBOL :ELEMENT-TYPE)) (:BOOLEAN T) (:TAG 2 (:SYMBOL :CONTENT))
     (:VECTOR 1 ((:NUMBER :INT8 0)))
     (:TMAP 3
      ((:SYMBOL ARRAY) (:REF 0)
       (:LIST 3 ((:NUMBER :INT8 1) (:NUMBER :INT8 1) (:BOOLEAN NIL))) (:REF 1)
       (:BOOLEAN T) (:REF 2) (:VECTOR 1 ((:NUMBER :INT8 0)))))
     (:BOOLEAN NIL) END-OF-FILE))
   END-OF-FILE))
 END-OF-FILE)

Notice the repeated :SYMBOL ARRAY and :SYMBOL BLARG

After fix:
((:LIST 5
  ((:TMAP 0 ((:TAG 0 (:SYMBOL BLARG)) (:TMAP 0 ((:REF 0)))))
   (:TMAP 3
    ((:TAG 1 (:SYMBOL ARRAY)) (:TAG 2 (:SYMBOL :DIMENSIONS))
     (:LIST 3 ((:NUMBER :INT8 1) (:NUMBER :INT8 1) (:BOOLEAN NIL)))
     (:TAG 3 (:SYMBOL :ELEMENT-TYPE)) (:BOOLEAN T) (:TAG 4 (:SYMBOL :CONTENT))
     (:VECTOR 1 ((:NUMBER :INT8 0)))
     (:TMAP 3
      ((:REF 1) (:REF 2)
       (:LIST 3 ((:NUMBER :INT8 1) (:NUMBER :INT8 1) (:BOOLEAN NIL))) (:REF 3)
       (:BOOLEAN T) (:REF 4) (:VECTOR 1 ((:NUMBER :INT8 0)))))
     (:BOOLEAN NIL) END-OF-FILE))
   END-OF-FILE))
 END-OF-FILE)
```